### PR TITLE
soong_config: Allow process-specific override of target SDK version

### DIFF
--- a/build/soong/android/variable.go
+++ b/build/soong/android/variable.go
@@ -9,6 +9,9 @@ type Product_variables struct {
 	Needs_text_relocations struct {
 		Cppflags []string
 	}
+	Target_process_sdk_version_override struct {
+		Cppflags []string
+	}
 	Target_shim_libs struct {
 		Cppflags []string
 	}
@@ -46,6 +49,7 @@ type ProductVariables struct {
 	Has_legacy_camera_hal1  *bool `json:",omitempty"`
 	Needs_text_relocations  *bool `json:",omitempty"`
 	Specific_camera_parameter_library  *string `json:",omitempty"`
+	Target_process_sdk_version_override *string `json:",omitempty"`
 	Target_shim_libs  *string `json:",omitempty"`
 	Uses_generic_camera_parameter_library  *bool `json:",omitempty"`
 	Uses_nvidia_enhancements  *bool `json:",omitempty"`

--- a/build/soong/soong_config.mk
+++ b/build/soong/soong_config.mk
@@ -10,6 +10,7 @@ $(call add_json_bool, Device_support_wait_for_qsee, $(filter true,$(TARGET_KEYMA
 $(call add_json_bool, Has_legacy_camera_hal1,                $(filter true,$(TARGET_HAS_LEGACY_CAMERA_HAL1)))
 $(call add_json_bool, Needs_text_relocations,                $(filter true,$(TARGET_NEEDS_PLATFORM_TEXT_RELOCATIONS)))
 $(call add_json_str,  Specific_camera_parameter_library,     $(TARGET_SPECIFIC_CAMERA_PARAMETER_LIBRARY))
+$(call add_json_str_omitempty, Target_process_sdk_version_override, $(TARGET_PROCESS_SDK_VERSION_OVERRIDE))
 $(call add_json_str,  Target_shim_libs,                      $(TARGET_LD_SHIM_LIBS))
 $(call add_json_str_omitempty, Additional_gralloc_10_usage_bits, $(TARGET_ADDITIONAL_GRALLOC_10_USAGE_BITS))
 $(call add_json_bool, Uses_generic_camera_parameter_library, $(if $(TARGET_SPECIFIC_CAMERA_PARAMETER_LIBRARY),,true))


### PR DESCRIPTION
With this, target can override target SDK version of specific process, for example, on bullhead you need to override SDK version to 27 for /vendor/bin/mm-qcamera-daemon, otherwise mm-qcamera-daemon will fail.
Base change: I65bbdbe96541d8aacdd4de125cdb9c1435129413

Change-Id: I775e852c17af12d2233e644e3db10c10bcb20d19