### PR TITLE
Revert "Show LTE instead of 4G"

### DIFF
--- a/overlay/common/frameworks/base/packages/SystemUI/res/values/config.xml
+++ b/overlay/common/frameworks/base/packages/SystemUI/res/values/config.xml
@@ -19,9 +19,6 @@
 <!-- These resources are around just to allow their values to be customized
      for different hardware and product builds. -->
 <resources>
-    <!-- Should "4G" be shown instead of "LTE" when the network is NETWORK_TYPE_LTE? -->
-    <bool name="config_show4GForLTE">false</bool>
-
     <!-- If true, enable the advance anti-falsing classifier on the lockscreen. On some devices it
          does not work well, particularly with noisy touchscreens. Note that disabling it may
          increase the rate of unintentional unlocks. -->


### PR DESCRIPTION
We now have a 4G/LTE toggle and dont require this anymore
This reverts commit 9bf5bccdf6bf3e34645d8bcefd2f6ca8668c332d.

Change-Id: Iaadbdf1ed71e267d2cd90c0914e6800dbe5b222e